### PR TITLE
enabled job and pod resource change via patch

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
@@ -152,7 +153,41 @@ func ValidateJobSpecUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path) fie
 	allErrs = append(allErrs, ValidateJobSpec(&spec, fldPath)...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Completions, oldSpec.Completions, fldPath.Child("completions"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Selector, oldSpec.Selector, fldPath.Child("selector"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Template, oldSpec.Template, fldPath.Child("template"))...)
+
+	// Validate immutable fields in job template
+	// Allowing PodSpec.Container.ResourceRequirements to change
+	newTemplate := spec.Template.DeepCopy()
+	oldTemplate := oldSpec.Template.DeepCopy()
+	resource := new(api.ResourceRequirements)
+	for i, _ := range newTemplate.Spec.Containers {
+		newTemplate.Spec.Containers[i].Resources = *resource
+	}
+	for i, _ := range oldTemplate.Spec.Containers {
+		oldTemplate.Spec.Containers[i].Resources = *resource
+	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newTemplate, oldTemplate, fldPath.Child("template"))...)
+	allErrs = append(allErrs, ValidateJobQOSImmutable(spec, oldSpec, fldPath.Child("template"))...)
+
+	return allErrs
+}
+
+func ValidateJobQOSImmutable(spec, oldSpec batch.JobSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	oldPod := api.Pod{
+		Spec: oldSpec.Template.Spec,
+	}
+	oldQOS := qos.GetPodQOS(&oldPod)
+
+	newPod := api.Pod{
+		Spec: spec.Template.Spec,
+	}
+	newQOS := qos.GetPodQOS(&newPod)
+
+	if newQOS != oldQOS {
+		allErrs = append(allErrs, field.Invalid(fldPath, newQOS, "Pod QOS is immutable"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -115,7 +115,7 @@ func TestValidationJobTemplateResourceUpdate(t *testing.T) {
 	}
 
 	// change qos
-	newQOSSpec := getPodTemplateSpecForResourceUpdate("11Gi", "11Gi", validGeneratedSelector) //GUARENTEE QOS
+	newQOSSpec := getPodTemplateSpecForResourceUpdate("11Gi", "11Gi", validGeneratedSelector) //GUARENTEED QOS
 	newQOSJobSpec := batch.JobSpec{
 		Selector: validGeneratedSelector,
 		Template: newQOSSpec,

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -20,8 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -48,6 +50,80 @@ func getValidPodTemplateSpecForManual(selector *metav1.LabelSelector) api.PodTem
 func getValidGeneratedSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{
 		MatchLabels: map[string]string{"controller-uid": "1a2b3c", "job-name": "myjob"},
+	}
+}
+
+func getPodTemplateSpecForResourceUpdate(request string, limit string, selector *metav1.LabelSelector) api.PodTemplateSpec {
+
+	rs := new(api.ResourceRequirements)
+	rs.Requests = make(api.ResourceList)
+	rs.Limits = make(api.ResourceList)
+
+	// BURSTABLE QOS, use "memory" to change to GUARENTEED
+	rs.Requests["memory"], _ = resource.ParseQuantity(request)
+	rs.Limits["memory"], _ = resource.ParseQuantity(limit)
+	rs.Requests["cpu"], _ = resource.ParseQuantity("4")
+	rs.Limits["cpu"], _ = resource.ParseQuantity("4")
+
+	return api.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: selector.MatchLabels,
+		},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyOnFailure,
+			DNSPolicy:     api.DNSClusterFirst,
+			Containers:    []api.Container{{Name: "abc", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: api.TerminationMessageReadFile, Resources: *rs}},
+		},
+	}
+}
+
+func TestValidationJobTemplateResourceUpdate(t *testing.T) {
+	validGeneratedSelector := getValidGeneratedSelector()
+	oldSpec := getPodTemplateSpecForResourceUpdate("5Gi", "10Gi", validGeneratedSelector)
+	newSpec := getPodTemplateSpecForResourceUpdate("6Gi", "11Gi", validGeneratedSelector)
+	newJobSpec := batch.JobSpec{
+		Selector: validGeneratedSelector,
+		Template: newSpec,
+	}
+
+	cases := map[string]batch.Job{
+		"update resource": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myjob",
+				Namespace: metav1.NamespaceDefault,
+				UID:       types.UID("1a2b3c"),
+			},
+			Spec: batch.JobSpec{
+				Selector: validGeneratedSelector,
+				Template: oldSpec,
+			},
+		},
+	}
+
+	for k, v := range cases {
+		if errs := ValidateJobSpecUpdate(newJobSpec, v.Spec, field.NewPath("spec")); len(errs) != 0 {
+			t.Errorf("expected success for %s: %v", k, errs)
+		}
+	}
+
+	// modifying an immutable field
+	newJobSpec.Template.Spec.Containers[0].Name = "newName"
+	for k, v := range cases {
+		if errs := ValidateJobSpecUpdate(newJobSpec, v.Spec, field.NewPath("spec")); len(errs) == 0 {
+			t.Errorf("expected failure for %s: %v", k, errs)
+		}
+	}
+
+	// change qos
+	newQOSSpec := getPodTemplateSpecForResourceUpdate("11Gi", "11Gi", validGeneratedSelector) //GUARENTEE QOS
+	newQOSJobSpec := batch.JobSpec{
+		Selector: validGeneratedSelector,
+		Template: newQOSSpec,
+	}
+	for k, v := range cases {
+		if errs := ValidateJobSpecUpdate(newQOSJobSpec, v.Spec, field.NewPath("spec")); len(errs) == 0 {
+			t.Errorf("expected failure for %s: %v", k, errs)
+		}
 	}
 }
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -45,6 +45,7 @@ import (
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
+	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	podshelper "k8s.io/kubernetes/pkg/apis/core/pods"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -3473,12 +3474,20 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newPod.Spec.ActiveDeadlineSeconds, "must not update from a positive integer to nil value"))
 	}
 
+	// check for QOS change
+	newQOS := qos.GetPodQOS(newPod)
+	oldQOS := qos.GetPodQOS(oldPod)
+	if newQOS != oldQOS {
+		allErrs = append(allErrs, field.Invalid(fldPath, newQOS, "Pod QOS is immutable"))
+	}
+
 	// handle updateable fields by munging those fields prior to deep equal comparison.
 	mungedPod := *newPod
 	// munge spec.containers[*].image
 	var newContainers []core.Container
 	for ix, container := range mungedPod.Spec.Containers {
 		container.Image = oldPod.Spec.Containers[ix].Image
+		container.Resources = oldPod.Spec.Containers[ix].Resources
 		newContainers = append(newContainers, container)
 	}
 	mungedPod.Spec.Containers = newContainers

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -8070,6 +8070,36 @@ func TestValidatePodUpdate(t *testing.T) {
 						{
 							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
+								Limits: getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Limits: getResourceLimits("100m", "3Gi"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"memory change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
 								Limits: getResourceLimits("100m", "0"),
 							},
 						},
@@ -8089,8 +8119,104 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 				},
 			},
-			"spec: Forbidden: pod updates may not change fields",
+			"",
 			"cpu change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Limits:   getResourceLimits("100m", "2Gi"),
+								Requests: getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Limits:   getResourceLimits("1000m", "3Gi"),
+								Requests: getResourceLimits("1000m", "3Gi"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"cpu and memory requests and limits change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "2Gi"),
+								Limits:   getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "3Gi"),
+								Limits:   getResourceLimits("100m", "3Gi"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"qos no change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "2Gi"),
+								Limits:   getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "3Gi"),
+								Limits:   getResourceLimits("100m", "4Gi"),
+							},
+						},
+					},
+				},
+			},
+			"Pod QOS is immutable",
+			"qos change",
 		},
 		{
 			core.Pod{

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -8081,7 +8081,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{
-							Image: "foo:V2",
+							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
 								Limits: getResourceLimits("100m", "3Gi"),
 							},
@@ -8111,7 +8111,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{
-							Image: "foo:V2",
+							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
 								Limits: getResourceLimits("1000m", "0"),
 							},
@@ -8142,7 +8142,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{
-							Image: "foo:V2",
+							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
 								Limits:   getResourceLimits("1000m", "3Gi"),
 								Requests: getResourceLimits("1000m", "3Gi"),
@@ -8174,7 +8174,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{
-							Image: "foo:V2",
+							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
 								Requests: getResourceLimits("100m", "3Gi"),
 								Limits:   getResourceLimits("100m", "3Gi"),
@@ -8206,7 +8206,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{
-							Image: "foo:V2",
+							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
 								Requests: getResourceLimits("100m", "3Gi"),
 								Limits:   getResourceLimits("100m", "4Gi"),


### PR DESCRIPTION
(1) enabled patch resource for both job and pod (cpu, memory, etc.)
(2) added check against qos change as a result of (1). qos change is not allowed
(3) updated and added unit tests

tested through unit and e2e tests on a local environment.