### PR TITLE
vertical scaling feature gate

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -156,7 +156,7 @@ func ValidateJobSpecUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path) fie
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Completions, oldSpec.Completions, fldPath.Child("completions"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Selector, oldSpec.Selector, fldPath.Child("selector"))...)
 
-	if !utilfeature.DefaultFeatureGate.Enabled(features.JobVerticalScaling) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Template, oldSpec.Template, fldPath.Child("template"))...)
 		return allErrs
 	}

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -24,10 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // TODO: generalize for other controller objects that will follow the same pattern, such as ReplicaSet and DaemonSet, and
@@ -153,6 +155,11 @@ func ValidateJobSpecUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path) fie
 	allErrs = append(allErrs, ValidateJobSpec(&spec, fldPath)...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Completions, oldSpec.Completions, fldPath.Child("completions"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Selector, oldSpec.Selector, fldPath.Child("selector"))...)
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.JobVerticalScaling) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Template, oldSpec.Template, fldPath.Child("template"))...)
+		return allErrs
+	}
 
 	// Validate immutable fields in job template
 	// Allowing PodSpec.Container.ResourceRequirements to change

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -24,8 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 func getValidManualSelector() *metav1.LabelSelector {
@@ -86,6 +89,8 @@ func TestValidationJobTemplateResourceUpdate(t *testing.T) {
 		Template: newSpec,
 	}
 
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, true)
+
 	cases := map[string]batch.Job{
 		"update resource": {
 			ObjectMeta: metav1.ObjectMeta{
@@ -125,6 +130,9 @@ func TestValidationJobTemplateResourceUpdate(t *testing.T) {
 			t.Errorf("expected failure for %s: %v", k, errs)
 		}
 	}
+
+	// unset feature gate for other tests
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, false)
 }
 
 func getValidPodTemplateSpecForGenerated(selector *metav1.LabelSelector) api.PodTemplateSpec {

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -89,7 +89,7 @@ func TestValidationJobTemplateResourceUpdate(t *testing.T) {
 		Template: newSpec,
 	}
 
-	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, true)
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VerticalScaling, true)
 
 	cases := map[string]batch.Job{
 		"update resource": {
@@ -132,7 +132,7 @@ func TestValidationJobTemplateResourceUpdate(t *testing.T) {
 	}
 
 	// unset feature gate for other tests
-	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, false)
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VerticalScaling, false)
 }
 
 func getValidPodTemplateSpecForGenerated(selector *metav1.LabelSelector) api.PodTemplateSpec {

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3487,7 +3487,7 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod) field.ErrorList {
 	var newContainers []core.Container
 	for ix, container := range mungedPod.Spec.Containers {
 		container.Image = oldPod.Spec.Containers[ix].Image
-		if utilfeature.DefaultFeatureGate.Enabled(features.JobVerticalScaling) {
+		if utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) {
 			container.Resources = oldPod.Spec.Containers[ix].Resources
 		}
 		newContainers = append(newContainers, container)

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3487,7 +3487,9 @@ func ValidatePodUpdate(newPod, oldPod *core.Pod) field.ErrorList {
 	var newContainers []core.Container
 	for ix, container := range mungedPod.Spec.Containers {
 		container.Image = oldPod.Spec.Containers[ix].Image
-		container.Resources = oldPod.Spec.Containers[ix].Resources
+		if utilfeature.DefaultFeatureGate.Enabled(features.JobVerticalScaling) {
+			container.Resources = oldPod.Spec.Containers[ix].Resources
+		}
 		newContainers = append(newContainers, container)
 	}
 	mungedPod.Spec.Containers = newContainers

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7657,6 +7657,193 @@ func TestValidatePod(t *testing.T) {
 	}
 }
 
+func TestValidatePodResourceUpdate(t *testing.T) {
+	tests := []struct {
+		new  core.Pod
+		old  core.Pod
+		err  string
+		test string
+	}{
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Limits: getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Limits: getResourceLimits("100m", "3Gi"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"memory change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Limits: getResourceLimits("100m", "0"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Limits: getResourceLimits("1000m", "0"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"cpu change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Limits:   getResourceLimits("100m", "2Gi"),
+								Requests: getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Limits:   getResourceLimits("1000m", "3Gi"),
+								Requests: getResourceLimits("1000m", "3Gi"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"cpu and memory requests and limits change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "2Gi"),
+								Limits:   getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "3Gi"),
+								Limits:   getResourceLimits("100m", "3Gi"),
+							},
+						},
+					},
+				},
+			},
+			"",
+			"qos no change",
+		},
+		{
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V1",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "2Gi"),
+								Limits:   getResourceLimits("100m", "2Gi"),
+							},
+						},
+					},
+				},
+			},
+			core.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: core.PodSpec{
+					Containers: []core.Container{
+						{
+							Image: "foo:V2",
+							Resources: core.ResourceRequirements{
+								Requests: getResourceLimits("100m", "3Gi"),
+								Limits:   getResourceLimits("100m", "4Gi"),
+							},
+						},
+					},
+				},
+			},
+			"Pod QOS is immutable",
+			"qos change",
+		},
+	}
+
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, true)
+	for _, test := range tests {
+		test.new.ObjectMeta.ResourceVersion = "1"
+		test.old.ObjectMeta.ResourceVersion = "1"
+		errs := ValidatePodUpdate(&test.new, &test.old)
+		if test.err == "" {
+			if len(errs) != 0 {
+				t.Errorf("unexpected invalid: %s (%+v)\nA: %+v\nB: %+v", test.test, errs, test.new, test.old)
+			}
+		} else {
+			if len(errs) == 0 {
+				t.Errorf("unexpected valid: %s\nA: %+v\nB: %+v", test.test, test.new, test.old)
+			} else if actualErr := errs.ToAggregate().Error(); !strings.Contains(actualErr, test.err) {
+				t.Errorf("unexpected error message: %s\nExpected error: %s\nActual error: %s", test.test, test.err, actualErr)
+			}
+		}
+	}
+
+	// unset feature gate for the other tests
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, false)
+}
+
 func TestValidatePodUpdate(t *testing.T) {
 	var (
 		activeDeadlineSecondsZero     = int64(0)
@@ -8070,36 +8257,6 @@ func TestValidatePodUpdate(t *testing.T) {
 						{
 							Image: "foo:V1",
 							Resources: core.ResourceRequirements{
-								Limits: getResourceLimits("100m", "2Gi"),
-							},
-						},
-					},
-				},
-			},
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Limits: getResourceLimits("100m", "3Gi"),
-							},
-						},
-					},
-				},
-			},
-			"",
-			"memory change",
-		},
-		{
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
 								Limits: getResourceLimits("100m", "0"),
 							},
 						},
@@ -8111,7 +8268,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec: core.PodSpec{
 					Containers: []core.Container{
 						{
-							Image: "foo:V1",
+							Image: "foo:V2",
 							Resources: core.ResourceRequirements{
 								Limits: getResourceLimits("1000m", "0"),
 							},
@@ -8119,104 +8276,8 @@ func TestValidatePodUpdate(t *testing.T) {
 					},
 				},
 			},
-			"",
+			"spec: Forbidden: pod updates may not change fields",
 			"cpu change",
-		},
-		{
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Limits:   getResourceLimits("100m", "2Gi"),
-								Requests: getResourceLimits("100m", "2Gi"),
-							},
-						},
-					},
-				},
-			},
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Limits:   getResourceLimits("1000m", "3Gi"),
-								Requests: getResourceLimits("1000m", "3Gi"),
-							},
-						},
-					},
-				},
-			},
-			"",
-			"cpu and memory requests and limits change",
-		},
-		{
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Requests: getResourceLimits("100m", "2Gi"),
-								Limits:   getResourceLimits("100m", "2Gi"),
-							},
-						},
-					},
-				},
-			},
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Requests: getResourceLimits("100m", "3Gi"),
-								Limits:   getResourceLimits("100m", "3Gi"),
-							},
-						},
-					},
-				},
-			},
-			"",
-			"qos no change",
-		},
-		{
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Requests: getResourceLimits("100m", "2Gi"),
-								Limits:   getResourceLimits("100m", "2Gi"),
-							},
-						},
-					},
-				},
-			},
-			core.Pod{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
-				Spec: core.PodSpec{
-					Containers: []core.Container{
-						{
-							Image: "foo:V1",
-							Resources: core.ResourceRequirements{
-								Requests: getResourceLimits("100m", "3Gi"),
-								Limits:   getResourceLimits("100m", "4Gi"),
-							},
-						},
-					},
-				},
-			},
-			"Pod QOS is immutable",
-			"qos change",
 		},
 		{
 			core.Pod{

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -7822,7 +7822,7 @@ func TestValidatePodResourceUpdate(t *testing.T) {
 		},
 	}
 
-	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, true)
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VerticalScaling, true)
 	for _, test := range tests {
 		test.new.ObjectMeta.ResourceVersion = "1"
 		test.old.ObjectMeta.ResourceVersion = "1"
@@ -7841,7 +7841,7 @@ func TestValidatePodResourceUpdate(t *testing.T) {
 	}
 
 	// unset feature gate for the other tests
-	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.JobVerticalScaling, false)
+	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VerticalScaling, false)
 }
 
 func TestValidatePodUpdate(t *testing.T) {

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -557,7 +557,7 @@ func (jm *JobController) syncJob(key string) (bool, error) {
 		return false, err
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.JobVerticalScaling) {
+	if utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) {
 		err = jm.patchJobResource(&job, pods)
 		if err != nil {
 			return false, err

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -321,7 +321,7 @@ const (
 	// alpha: v1.11
 	//
 	// Allow job veritical scaling
-	JobVerticalScaling utilfeature.Feature = "JobVerticalScaling"
+	VerticalScaling utilfeature.Feature = "VerticalScaling"
 
 	// owner: @vikaschoudhary16
 	// alpha: v1.11
@@ -408,7 +408,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	DynamicProvisioningScheduling:               {Default: false, PreRelease: utilfeature.Alpha},
 	PodReadinessGates:                           {Default: false, PreRelease: utilfeature.Beta},
 	VolumeSubpathEnvExpansion:                   {Default: false, PreRelease: utilfeature.Alpha},
-	JobVerticalScaling:                          {Default: false, PreRelease: utilfeature.Alpha},
+	VerticalScaling:                          {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPluginsWatcher:                       {Default: false, PreRelease: utilfeature.Alpha},
 	ResourceQuotaScopeSelectors:                 {Default: false, PreRelease: utilfeature.Alpha},
 	CSIBlockVolume:                              {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -317,6 +317,16 @@ const (
 	// Extend the default scheduler to be aware of volume topology and handle PV provisioning
 	DynamicProvisioningScheduling utilfeature.Feature = "DynamicProvisioningScheduling"
 
+	// owner: @XiaoningDing
+	// alpha: v1.11
+	//
+	// Allow job veritical scaling
+	JobVerticalScaling utilfeature.Feature = "JobVerticalScaling"
+
+	// owner: @vikaschoudhary16
+	// alpha: v1.11
+	//
+	//
 	// owner: @kevtaylor
 	// alpha: v1.11
 	//
@@ -398,6 +408,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	DynamicProvisioningScheduling:               {Default: false, PreRelease: utilfeature.Alpha},
 	PodReadinessGates:                           {Default: false, PreRelease: utilfeature.Beta},
 	VolumeSubpathEnvExpansion:                   {Default: false, PreRelease: utilfeature.Alpha},
+	JobVerticalScaling:                          {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletPluginsWatcher:                       {Default: false, PreRelease: utilfeature.Alpha},
 	ResourceQuotaScopeSelectors:                 {Default: false, PreRelease: utilfeature.Alpha},
 	CSIBlockVolume:                              {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
(1) added vertical scaling feature gate (apiserver and job controller)
(2) refactored unit tests for cases where feature gate is enabled and disabled

tested by unit tests and local integration tests

To use: added --feature-gates=VerticalScaling=true to apiserver and controller-manager start up flag to enable job vertical scaling. by default it's disabled. 

