### PR TITLE
added resource quota control for pod resource update

### DIFF
--- a/pkg/quota/evaluator/core/pods.go
+++ b/pkg/quota/evaluator/core/pods.go
@@ -147,7 +147,7 @@ func (p *podEvaluator) GroupResource() schema.GroupResource {
 // Handles returns true if the evaluator should handle the specified attributes.
 func (p *podEvaluator) Handles(a admission.Attributes) bool {
 	op := a.GetOperation()
-	if op == admission.Create {
+	if op == admission.Create || op == admission.Update {
 		return true
 	}
 	initializationCompletion, err := util.IsInitializationCompletion(a)

--- a/pkg/quota/generic/evaluator.go
+++ b/pkg/quota/generic/evaluator.go
@@ -189,7 +189,7 @@ func (o *objectCountEvaluator) Constraints(required []api.ResourceName, item run
 // Handles returns true if the object count evaluator needs to track this attributes.
 func (o *objectCountEvaluator) Handles(a admission.Attributes) bool {
 	operation := a.GetOperation()
-	return operation == admission.Create || (o.allowCreateOnUpdate && operation == admission.Update)
+	return operation == admission.Create || operation == admission.Update
 }
 
 // Matches returns true if the evaluator matches the specified quota with the provided input item

--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -538,6 +538,7 @@ func (e *quotaEvaluator) checkRequest(quotas []api.ResourceQuota, a admission.At
 
 		hardResources := quota.ResourceNames(resourceQuota.Status.Hard)
 		requestedUsage := quota.Mask(deltaUsage, hardResources)
+		glog.Infof("xxxxxx %+v", deltaUsage)
 		newUsage := quota.Add(resourceQuota.Status.Used, requestedUsage)
 		maskedNewUsage := quota.Mask(newUsage, quota.ResourceNames(requestedUsage))
 

--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -538,7 +538,6 @@ func (e *quotaEvaluator) checkRequest(quotas []api.ResourceQuota, a admission.At
 
 		hardResources := quota.ResourceNames(resourceQuota.Status.Hard)
 		requestedUsage := quota.Mask(deltaUsage, hardResources)
-		glog.Infof("xxxxxx %+v", deltaUsage)
 		newUsage := quota.Add(resourceQuota.Status.Used, requestedUsage)
 		maskedNewUsage := quota.Mask(newUsage, quota.ResourceNames(requestedUsage))
 


### PR DESCRIPTION
Added resource quota check for pod resource update

On failure, pod resource update will fail with message like the following:
"Pod test-7nfc7 resizing update error: pods "test-7nfc7" is forbidden: exceeded quota: rq, requested: limits.memory=15Gi,requests.memory=15Gi, used: limits.memory=7Gi,requests.memory=7Gi, limited: limits.memory=9Gi,requests.memory=9Gi"

Added unit tests. Also tested on the local e2e environment.