### PR TITLE
Update cached pod resources values on resizing updates

### DIFF
--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -243,7 +243,7 @@ func (cache *schedulerCache) addPod(pod *v1.Pod) {
 }
 
 // this function expects valid pod, and valid, non-empty resizeRequestAnnotation json string
-func (cache *schedulerCache) getPodResizeRequirements(pod *v1.Pod, resizeRequestAnnotation string) (map[string]v1.Container, *Resource, error) {
+func getPodResizeRequirements(pod *v1.Pod, resizeRequestAnnotation string) (map[string]v1.Container, *Resource, error) {
 	var resizeContainers []v1.Container
 
 	if err := json.Unmarshal([]byte(resizeRequestAnnotation), &resizeContainers); err != nil {
@@ -270,22 +270,27 @@ func (cache *schedulerCache) getPodResizeRequirements(pod *v1.Pod, resizeRequest
 	return resizeContainersMap, podResource, nil
 }
 
-func restoreResources(pod *v1.Pod, restoreResources string) error {
+func (cache *schedulerCache) restoreResources(oldPod, newPod *v1.Pod, restoreResources string) error {
+	podKey, _ := getPodKey(oldPod)
+	currPodState, _ := cache.podStates[podKey]
+	cachedPod := currPodState.pod
 	restoreContainersMap := make(map[string]v1.Container)
 	if err := json.Unmarshal([]byte(restoreResources), &restoreContainersMap); err != nil {
-		glog.Errorf("Pod %s unmarshalling restore resource annotation '%s' failed. Error: %v", pod.Name, restoreResources, err)
+		glog.Errorf("Pod %s unmarshalling restore resource annotation '%s' failed. Error: %v", newPod.Name, restoreResources, err)
 		return err
 	}
-	for i, container := range pod.Spec.Containers {
+	for i, container := range newPod.Spec.Containers {
 		if restoreContainer, ok := restoreContainersMap[container.Name]; ok {
 			if restoreContainer.Resources.Requests != nil {
 				for k, v := range restoreContainer.Resources.Requests {
-					pod.Spec.Containers[i].Resources.Requests[k] = v
+					newPod.Spec.Containers[i].Resources.Requests[k] = v
+					cachedPod.Spec.Containers[i].Resources.Requests[k] = v
 				}
 			}
 			if restoreContainer.Resources.Limits != nil {
 				for k, v := range restoreContainer.Resources.Limits {
-					pod.Spec.Containers[i].Resources.Limits[k] = v
+					newPod.Spec.Containers[i].Resources.Limits[k] = v
+					cachedPod.Spec.Containers[i].Resources.Limits[k] = v
 				}
 			}
 		}
@@ -293,7 +298,7 @@ func restoreResources(pod *v1.Pod, restoreResources string) error {
 	return nil
 }
 
-func (cache *schedulerCache) processPodResourcesResizeRequest(newPod *v1.Pod) error {
+func (cache *schedulerCache) processPodResourcesResizeRequest(oldPod, newPod *v1.Pod) error {
 	node, ok := cache.nodes[newPod.Spec.NodeName]
 	if !ok {
 		errMsg := fmt.Sprintf("Node %s not found for pod %s", newPod.Spec.NodeName, newPod.Name)
@@ -314,7 +319,7 @@ func (cache *schedulerCache) processPodResourcesResizeRequest(newPod *v1.Pod) er
 				// If ResizeStatus shows failure, restore previous resource values
 				if podCondition.Status == v1.ConditionFalse {
 					if previousResources, ok := newPod.ObjectMeta.Annotations[api.AnnotationResizeResourcesPrevious]; ok {
-						restoreResources(newPod, previousResources)
+						cache.restoreResources(oldPod, newPod, previousResources)
 					}
 				}
 				delete(newPod.ObjectMeta.Annotations, api.AnnotationResizeResourcesPrevious)
@@ -334,13 +339,16 @@ func (cache *schedulerCache) processPodResourcesResizeRequest(newPod *v1.Pod) er
 			return nil
 		}
 
-		if resizeContainersMap, podResource, err := cache.getPodResizeRequirements(newPod, resizeRequestAnnotation); err == nil {
+		if resizeContainersMap, podResource, err := getPodResizeRequirements(newPod, resizeRequestAnnotation); err == nil {
 			allocatable := node.AllocatableResource()
 			nodeMilliCPU := node.RequestedResource().MilliCPU
 			nodeMemory := node.RequestedResource().Memory
 			if (allocatable.MilliCPU > (podResource.MilliCPU + nodeMilliCPU)) &&
 				(allocatable.Memory > (podResource.Memory + nodeMemory)) {
 				// InPlace resizing is possible
+				podKey, _ := getPodKey(oldPod)
+				currPodState, _ := cache.podStates[podKey]
+				cachedPod := currPodState.pod
 				restoreContainersMap := make(map[string]v1.Container)
 				for i, container := range newPod.Spec.Containers {
 					resizeContainer, ok := resizeContainersMap[container.Name]
@@ -358,22 +366,24 @@ func (cache *schedulerCache) processPodResourcesResizeRequest(newPod *v1.Pod) er
 						if resizeContainer.Resources.Requests != nil {
 							for k, v := range resizeContainer.Resources.Requests {
 								newPod.Spec.Containers[i].Resources.Requests[k] = v
+								cachedPod.Spec.Containers[i].Resources.Requests[k] = v
 							}
 						}
 						if resizeContainer.Resources.Limits != nil {
 							for k, v := range resizeContainer.Resources.Limits {
 								newPod.Spec.Containers[i].Resources.Limits[k] = v
+								cachedPod.Spec.Containers[i].Resources.Limits[k] = v
 							}
 						}
 					}
 				}
-				if jsonStr, err := json.Marshal(restoreContainersMap); err != nil {
-					glog.Errorf("Pod %s resources restore map json marshal failed. Error: %v", newPod.Name, err)
+				if restoreResourcesJson, err := json.Marshal(restoreContainersMap); err != nil {
+					glog.Errorf("Pod %s restore resources json marshal failed. Error: %v", newPod.Name, err)
 					return err
 				} else {
 					newPod.ObjectMeta.Annotations[api.AnnotationResizeResourcesActionVer] = string(newPod.ObjectMeta.ResourceVersion)
 					newPod.ObjectMeta.Annotations[api.AnnotationResizeResourcesAction] = string(api.ResizeActionUpdate)
-					newPod.ObjectMeta.Annotations[api.AnnotationResizeResourcesPrevious] = string(jsonStr)
+					newPod.ObjectMeta.Annotations[api.AnnotationResizeResourcesPrevious] = string(restoreResourcesJson)
 				}
 			} else {
 				// InPlace resizing is not possible, restart if allowed by policy
@@ -404,7 +414,7 @@ func (cache *schedulerCache) updatePod(oldPod, newPod *v1.Pod) error {
 	// Resize request is valid for running pods
 	if utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) &&
 		oldPod.Status.Phase == v1.PodRunning && newPod.Status.Phase == v1.PodRunning {
-		err = cache.processPodResourcesResizeRequest(newPod)
+		err = cache.processPodResourcesResizeRequest(oldPod, newPod)
 	}
 	cache.addPod(newPod)
 	return err

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -660,7 +660,7 @@ func (c *configFactory) updatePodInCache(oldObj, newObj interface{}) {
 			case schedulerapi.ResizeActionUpdate:
 				// Case 1. Node has capacity. Update.
 				updatedPod, err := c.client.CoreV1().Pods(newPod.Namespace).Update(newPod)
-				if err !=  nil {
+				if err != nil {
 					glog.Errorf("Error updating pod %s for resizing: %+v", newPod.Name, err)
 					c.recorder.Eventf(newPod, v1.EventTypeWarning, "PodInPlaceResizeFailed", "Pod %s resizing update error: %v.", podName, err)
 				} else {
@@ -682,7 +682,7 @@ func (c *configFactory) updatePodInCache(oldObj, newObj interface{}) {
 				// Case 3. Node does not have capacity. Pod reschedule blocked by policy. Update pod.
 				c.recorder.Eventf(newPod, v1.EventTypeNormal, "PodResizeRescheduleBlockedByPolicy", "Pod %s was not rescheduled for resizing due to policy", podName)
 				updatedPod, err := c.client.CoreV1().Pods(newPod.Namespace).Update(newPod)
-				if err !=  nil {
+				if err != nil {
 					glog.Errorf("Error updating pod %s that was not rescheduled for resizing due to policy: %+v", podName, err)
 				} else {
 					glog.V(4).Infof("Pod %s that was not rescheduled for resizing due to policy", updatedPod.Name)

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -670,10 +670,8 @@ func (c *configFactory) updatePodInCache(oldObj, newObj interface{}) {
 			case schedulerapi.ResizeActionReschedule:
 				// Case 2. Node does not have capacity. Delete pod, let controller re-create pod.
 				c.recorder.Eventf(newPod, v1.EventTypeNormal, "DeletePodForResizeReschedule", "Deleting pod %s to reschedule for resizing", podName)
-				deleteOptions := metav1.NewDeleteOptions(0)
-				deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(newPod.UID))
 				delete(newPod.ObjectMeta.Annotations, schedulerapi.AnnotationResizeResourcesActionVer)
-				if err := c.client.CoreV1().Pods(newPod.Namespace).Delete(newPod.Name, deleteOptions); err != nil {
+				if err := c.client.CoreV1().Pods(newPod.Namespace).Delete(newPod.Name, nil); err != nil {
 					glog.Errorf("Error deleting pod %s for resizing: %+v", newPod.Name, err)
 					c.recorder.Eventf(newPod, v1.EventTypeWarning, "PodRescheduleForResizeFailed", "Pod %s delete for resizing error: %v", podName, err)
 				} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 
   Scheduler caches the initial pod that gets Added, and deletes cached Pod.
   So subsequent pod resource updates makes cached pod resource values to become stale.
   This fix updates cached pod resource values so the delete deducts the correct values.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
