### PR TITLE
Respect pod disruption budget when rescheduling pods for resource resizing. Refactor code.

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -65,19 +65,22 @@ const (
 // PodResourcesResizeAction is the action determined by scheduler in response to pod vertical resize request.
 type PodResourcesResizeAction string
 const (
-	ResizeActionUpdate        PodResourcesResizeAction = "UpdatePodForResizing"
-	ResizeActionReschedule    PodResourcesResizeAction = "DeletePodForResizing"
-	ResizeActionNonePerPolicy PodResourcesResizeAction = "PodNotResizedDueToPolicy"
-	ResizeActionUpdateDone    PodResourcesResizeAction = "UpdatePodResizingDone"
+	ResizeActionUpdate              PodResourcesResizeAction = "UpdatePodForResizing"
+	ResizeActionReschedule          PodResourcesResizeAction = "DeletePodForResizing"
+	ResizeActionNonePerPolicy       PodResourcesResizeAction = "PodNotResizedDueToPolicy"
+	ResizeActionNonePerPDBViolation PodResourcesResizeAction = "PodNotResizedDueToPDBViolation"
+	ResizeActionUpdateDone          PodResourcesResizeAction = "UpdatePodResizingDone"
 )
 
 const (
 	// Pod not rescheduled to resize resources due to InPlaceOnly policy
-	PodResourcesResizeStatusBlockedByPolicy = "PodNotResizedDueToPolicy"
+	PodResourcesResizeStatusBlockedByPolicy       = "PodNotResizedDueToPolicy"
+	// Pod not rescheduled to resize resources due to PDB violation
+	PodResourcesResizeStatusBlockedByPDBViolation = "PodNotResizedDueToPDBViolation"
 	// Pod resources resizing request failed
-	PodResourcesResizeStatusFailed          = "PodResourceResizeFailed"
+	PodResourcesResizeStatusFailed                = "PodResourceResizeFailed"
 	// Pod resources resizing request was successful
-	PodResourcesResizeStatusSuccessful      = "PodResourceResizeSuccessful"
+	PodResourcesResizeStatusSuccessful            = "PodResourceResizeSuccessful"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -648,14 +648,14 @@ func (c *configFactory) updatePodInCache(oldObj, newObj interface{}) {
 
 	// Call Update only if we modified the pod resources
 	if utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) && !reflect.DeepEqual(oldPod, newPod) {
-		if resizeActionAnnotation, ok := newPod.ObjectMeta.Annotations[schedulerapi.AnnotationResizeResourcesAction]; ok &&
-			newPod.ObjectMeta.ResourceVersion == newPod.ObjectMeta.Annotations[schedulerapi.AnnotationResizeResourcesActionVer] {
+		if resizeActionAnnotation, ok := newPod.Annotations[schedulerapi.AnnotationResizeResourcesAction]; ok &&
+			newPod.ResourceVersion == newPod.Annotations[schedulerapi.AnnotationResizeResourcesActionVer] {
 			podName := newPod.Name
 			switch schedulerapi.PodResourcesResizeAction(resizeActionAnnotation) {
 			case schedulerapi.ResizeActionUpdateDone:
 				c.recorder.Eventf(newPod, v1.EventTypeNormal, "PodResizeRequestComplete", "Pod %s resize request handling complete", podName)
-				delete(newPod.ObjectMeta.Annotations, schedulerapi.AnnotationResizeResourcesActionVer)
-				delete(newPod.ObjectMeta.Annotations, schedulerapi.AnnotationResizeResourcesAction)
+				delete(newPod.Annotations, schedulerapi.AnnotationResizeResourcesActionVer)
+				delete(newPod.Annotations, schedulerapi.AnnotationResizeResourcesAction)
 				fallthrough
 			case schedulerapi.ResizeActionUpdate:
 				// Case 1. Node has capacity. Update.
@@ -670,8 +670,10 @@ func (c *configFactory) updatePodInCache(oldObj, newObj interface{}) {
 			case schedulerapi.ResizeActionReschedule:
 				// Case 2. Node does not have capacity. Delete pod, let controller re-create pod.
 				c.recorder.Eventf(newPod, v1.EventTypeNormal, "DeletePodForResizeReschedule", "Deleting pod %s to reschedule for resizing", podName)
-				delete(newPod.ObjectMeta.Annotations, schedulerapi.AnnotationResizeResourcesActionVer)
-				if err := c.client.CoreV1().Pods(newPod.Namespace).Delete(newPod.Name, nil); err != nil {
+				delete(newPod.Annotations, schedulerapi.AnnotationResizeResourcesActionVer)
+				deleteOptions := metav1.NewDeleteOptions(0)
+				deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(newPod.UID))
+				if err := c.client.CoreV1().Pods(newPod.Namespace).Delete(newPod.Name, deleteOptions); err != nil {
 					glog.Errorf("Error deleting pod %s for resizing: %+v", newPod.Name, err)
 					c.recorder.Eventf(newPod, v1.EventTypeWarning, "PodRescheduleForResizeFailed", "Pod %s delete for resizing error: %v", podName, err)
 				} else {
@@ -684,6 +686,15 @@ func (c *configFactory) updatePodInCache(oldObj, newObj interface{}) {
 				updatedPod, err := c.client.CoreV1().Pods(newPod.Namespace).Update(newPod)
 				if err != nil {
 					glog.Errorf("Error updating pod %s that was not rescheduled for resizing due to policy: %+v", podName, err)
+				} else {
+					glog.V(4).Infof("Pod %s that was not rescheduled for resizing due to policy", updatedPod.Name)
+				}
+			case schedulerapi.ResizeActionNonePerPDBViolation:
+				// Case 4. Pod reschedule blocked because it violates PDB. Update pod.
+				c.recorder.Eventf(newPod, v1.EventTypeNormal, "PodResizeRescheduleBlockedByPDBViolation", "Pod %s was not rescheduled for resizing due to pod disruption budget", podName)
+				updatedPod, err := c.client.CoreV1().Pods(newPod.Namespace).Update(newPod)
+				if err != nil {
+					glog.Errorf("Error updating pod %s that was not rescheduled for resizing due to PDB violation: %+v", podName, err)
 				} else {
 					glog.V(4).Infof("Pod %s that was not rescheduled for resizing due to policy", updatedPod.Name)
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Pod disruption budget allows user to specify how many of their 
desired pod count they can have offline at any given time. For resource resizing request processing, this means that we need to not reschedule the pod if doing so would violate the pod disruption budget. This change adds the feature.

There are also a bunch of bug fixes and scheduler code-refactoring to make it easier to write unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
