### PR TITLE
added retry for resource update failure

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -512,11 +512,11 @@ func (jm *JobController) patchJobResource(j *batch.Job, pods []*v1.Pod) error {
 
 	for _, pod := range pods {
 		// Skip if a resource update is in flight
-		if _, ok := pod.ObjectMeta.Annotations[schedulerapi.AnnotationResizeResourcesRequest]; ok {
+		if _, ok := pod.Annotations[schedulerapi.AnnotationResizeResourcesRequest]; ok {
 			glog.Warningf("A resource update is in progress for pod %s. Skipping pod.", pod.Name)
 			continue
 		}
-		if _, ok := pod.ObjectMeta.Annotations[schedulerapi.AnnotationResizeResourcesAction]; ok {
+		if _, ok := pod.Annotations[schedulerapi.AnnotationResizeResourcesAction]; ok {
 			glog.Warningf("A resource update is in progress for pod %s. Skipping pod.", pod.Name)
 			continue
 		}
@@ -538,7 +538,7 @@ func (jm *JobController) patchJobResource(j *batch.Job, pods []*v1.Pod) error {
 						}
 
 						delete(jm.jobsToReSyncResource, j.UID)
-						glog.V(4).Infof("Retrying Resource resizing for pod %s by job %s version %s.", pod.Name, j.Name, j.ResourceVersion)
+						glog.V(4).Infof("Retrying resource resizing for pod %s by job %s version %s.", pod.Name, j.Name, j.ResourceVersion)
 					}
 				}
 			}
@@ -548,13 +548,8 @@ func (jm *JobController) patchJobResource(j *batch.Job, pods []*v1.Pod) error {
 			anno[schedulerapi.AnnotationResizeResourcesRequestVer] = j.ResourceVersion
 			anno[schedulerapi.AnnotationResizeResourcesRequest] = string(jsonStr)
 
-			// only patch new annotation. ignore duplicate
-			if pod.Annotations == nil || pod.Annotations[schedulerapi.AnnotationResizeResourcesRequest] != anno[schedulerapi.AnnotationResizeResourcesRequest] {
-				cm.PatchPodResourceAnnotation(pod, anno)
-				glog.V(6).Infof("Adding resource update annotation %v to pod %s", anno, pod.Name)
-			} else {
-				glog.V(6).Infof("Ignored attempt to patch duplicated annotation %v to pod %s", anno, pod.Name)
-			}
+			cm.PatchPodResourceAnnotation(pod, anno)
+			glog.V(6).Infof("Adding resource update annotation %v to pod %s", anno, pod.Name)
 		}
 	}
 	return nil

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -296,9 +296,14 @@ func (jm *JobController) updatePod(old, cur interface{}) {
 
 	// retry (enqueue) jobs failed from resource update
 	if !reflect.DeepEqual(curPod.Spec.Containers, oldPod.Spec.Containers) && !hasFailedResourceResizeStatus(curPod) {
+
+		// non-existing AnnotationResizeResourcesRequest indicates a non-inflight resource request
 		if _, ok := curPod.Annotations[schedulerapi.AnnotationResizeResourcesRequest]; !ok {
-			if key, ok := curPod.Annotations[schedulerapi.AnnotationResizeResourcesAction]; ok && key == string(schedulerapi.ResizeActionUpdateDone) {
-				jm.enqueueResourceUpdateForRetry()
+			// non-existing AnnotationResizeResourcesAction and AnnotationResizeResourcesActionVer indicates a succeeded resource update
+			if _, ok := curPod.Annotations[schedulerapi.AnnotationResizeResourcesAction]; !ok {
+				if _, ok := curPod.Annotations[schedulerapi.AnnotationResizeResourcesActionVer]; !ok {
+					jm.enqueueResourceUpdateForRetry()
+				}
 			}
 		}
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2091,15 +2091,15 @@ func (kl *Kubelet) isPodResourceUpdateAcceptable(pod *v1.Pod) bool {
 			}
 		}
 
-		// Upate pod status
+		// Update pod status
 		resizeStatus := v1.PodCondition{
-				Type:               v1.PodResourcesResizeStatus,
-				Status:             conditionStatus,
-				Reason:             reason,
-				Message:            pod.Annotations[schedulerapi.AnnotationResizeResourcesActionVer],
-				LastTransitionTime: metav1.Now(),
-				LastProbeTime:      metav1.Now(),
-			}
+			Type:               v1.PodResourcesResizeStatus,
+			Status:             conditionStatus,
+			Reason:             reason,
+			Message:            pod.Annotations[schedulerapi.AnnotationResizeResourcesActionVer],
+			LastTransitionTime: metav1.Now(),
+			LastProbeTime:      metav1.Now(),
+		}
 		idx := -1
 		for i, podCondition := range pod.Status.Conditions {
 			if podCondition.Type == v1.PodResourcesResizeStatus {

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -400,7 +400,7 @@ func (cache *schedulerCache) processPodResourcesScaling(oldPod, newPod *v1.Pod) 
 		return errors.New(errMsg)
 	}
 
-	// resoure resize policy is defaulted to InPlacePreferred
+	// resource resize policy is defaulted to InPlacePreferred
 	resizeResourcesPolicy := api.ResizePolicyInPlacePreferred
 	if _, ok := newPod.Annotations[api.AnnotationResizeResourcesPolicy]; ok {
 		resizeResourcesPolicy = api.PodResourcesResizePolicy(newPod.Annotations[api.AnnotationResizeResourcesPolicy])

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -106,8 +106,8 @@ type configFactory struct {
 	pdbLister policylisters.PodDisruptionBudgetLister
 	// a means to list all StorageClasses
 	storageClassLister storagelisters.StorageClassLister
-        // Recorder is the EventRecorder to use
-        recorder record.EventRecorder
+	// Recorder is the EventRecorder to use
+	recorder record.EventRecorder
 
 	// Close this to stop all reflectors
 	StopEverything chan struct{}
@@ -182,7 +182,7 @@ func NewConfigFactory(
 		statefulSetLister:              statefulSetInformer.Lister(),
 		pdbLister:                      pdbInformer.Lister(),
 		storageClassLister:             storageClassLister,
-		recorder:			eventRecorder,
+		recorder:                       eventRecorder,
 		schedulerCache:                 schedulerCache,
 		StopEverything:                 stopEverything,
 		schedulerName:                  schedulerName,


### PR DESCRIPTION
Add resource update failure retry when the following events happen:

1. another pod has successfully changed its container info, and/or
2. pod and/or controller are deleted

Tested with manually E2E on local environment with the following cases

1. a single pod failed resource update
2. another pod from another job failed resource update
3. delete the controller that owns the failed pod
4. delete the controller that does not own the failed pod
5. delete the pod that's failed
6. delete the pod that's not failed