### PR TITLE
Fix ordering of pod-level cgroup limits update and container-level CRI resource update

### DIFF
--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -92,7 +92,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	if len(cm.cgroupRoot) > 0 {
 		go func() {
 			for {
-				err := cm.cgroupManager.Update(cgroupConfig)
+				err := cm.cgroupManager.Update(cgroupConfig, nil)
 				if err == nil {
 					cm.recorder.Event(nodeRef, v1.EventTypeNormal, events.SuccessfulNodeAllocatableEnforcement, "Updated Node Allocatable limit across pods")
 					return
@@ -135,7 +135,7 @@ func enforceExistingCgroup(cgroupManager CgroupManager, cName CgroupName, rl v1.
 	if !cgroupManager.Exists(cgroupConfig.Name) {
 		return fmt.Errorf("%q cgroup does not exist", cgroupConfig.Name)
 	}
-	if err := cgroupManager.Update(cgroupConfig); err != nil {
+	if err := cgroupManager.Update(cgroupConfig, nil); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -34,6 +34,18 @@ func (m *podContainerManagerStub) EnsureExists(_ *v1.Pod) error {
 	return nil
 }
 
+func (m *podContainerManagerStub) GetPodCgroupCpuLimit(_ *v1.Pod) (int64, uint64, uint64, error) {
+	return 0, 0, 0, nil
+}
+
+func (m *podContainerManagerStub) GetPodCgroupMemoryLimit(_ *v1.Pod) (uint64, error) {
+	return 0, nil
+}
+
+func (m *podContainerManagerStub) Update(_ *v1.Pod, _ []string) error {
+	return nil
+}
+
 func (m *podContainerManagerStub) GetPodContainerName(_ *v1.Pod) (CgroupName, string) {
 	return nil, ""
 }

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -119,7 +119,7 @@ func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceLis
 			}
 		} else {
 			// to ensure we actually have the right state, we update the config on startup
-			if err := cm.Update(containerConfig); err != nil {
+			if err := cm.Update(containerConfig, nil); err != nil {
 				return fmt.Errorf("failed to update top level %v QOS cgroup : %v", qosClass, err)
 			}
 		}
@@ -306,7 +306,7 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
 
 		updateSuccess := true
 		for _, config := range qosConfigs {
-			err := m.cgroupManager.Update(config)
+			err := m.cgroupManager.Update(config, nil)
 			if err != nil {
 				updateSuccess = false
 			}
@@ -328,7 +328,7 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
 	}
 
 	for _, config := range qosConfigs {
-		err := m.cgroupManager.Update(config)
+		err := m.cgroupManager.Update(config, nil)
 		if err != nil {
 			glog.Errorf("[ContainerManager]: Failed to update QoS cgroup configuration")
 			return err

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -19,6 +19,7 @@ package cm
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
 // ResourceConfig holds information about all the supported cgroup resource parameters.
@@ -77,7 +78,7 @@ type CgroupManager interface {
 	// Destroy the cgroup.
 	Destroy(*CgroupConfig) error
 	// Update cgroup configuration.
-	Update(*CgroupConfig) error
+	Update(*CgroupConfig, []string) error
 	// Exists checks if the cgroup already exists
 	Exists(name CgroupName) bool
 	// Name returns the literal cgroupfs name on the host after any driver specific conversions.
@@ -94,6 +95,8 @@ type CgroupManager interface {
 	ReduceCPULimits(cgroupName CgroupName) error
 	// GetResourceStats returns statistics of the specified cgroup as read from the cgroup fs.
 	GetResourceStats(name CgroupName) (*ResourceStats, error)
+	// GetCgroupStats returns statistics of the specified cgroup as read from the cgroup fs.
+	GetCgroupStats(name CgroupName) (*cgroups.Stats, error)
 }
 
 // QOSContainersInfo stores the names of containers per qos
@@ -117,6 +120,15 @@ type PodContainerManager interface {
 
 	// Exists returns true if the pod cgroup exists.
 	Exists(*v1.Pod) bool
+
+	// Get current values of cpu.cfs_quota_us, cpu.cfs_period_us, cpu.shares for Pod Cgroup
+	GetPodCgroupCpuLimit(*v1.Pod) (int64, uint64, uint64, error)
+
+	// Get current values of memory.limit_in_bytes for Pod Cgroup
+	GetPodCgroupMemoryLimit(*v1.Pod) (uint64, error)
+
+	// Update takes a pod as argument, and updates the Cgroup limits for the pod.
+	Update(*v1.Pod, []string) error
 
 	// Destroy takes a pod Cgroup name as argument and destroys the pod's container.
 	Destroy(name CgroupName) error

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -672,7 +672,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		kubeCfg.CPUCFSQuota,
 		runtimeService,
 		imageService,
-		kubeDeps.ContainerManager.InternalContainerLifecycle(),
+		kubeDeps.ContainerManager,
 		legacyLogProvider,
 	)
 	if err != nil {
@@ -1565,24 +1565,9 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 				if err := kl.containerManager.UpdateQOSCgroups(); err != nil {
 					glog.V(2).Infof("Failed to update QoS cgroups while syncing pod: %v", err)
 				}
-				if !utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) {
-					// create or update cgroup settings based on pod resource spec
-					if err := pcm.EnsureExists(pod); err != nil {
-						kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToCreatePodContainer, "unable to ensure pod container exists: %v", err)
-						return fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
-					}
-
-				}
-			}
-
-			if utilfeature.DefaultFeatureGate.Enabled(features.VerticalScaling) {
-				// create or update cgroup settings based on pod resource spec
 				if err := pcm.EnsureExists(pod); err != nil {
 					kl.recorder.Eventf(pod, v1.EventTypeWarning, events.FailedToCreatePodContainer, "unable to ensure pod container exists: %v", err)
 					return fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
-				}
-				if err := kl.containerManager.UpdateQOSCgroups(); err != nil {
-					glog.V(2).Infof("Failed to update QoS cgroups while syncing pod: %v", err)
 				}
 			}
 		}

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpu.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs/cpu.go
@@ -121,5 +121,22 @@ func (s *CpuGroup) GetStats(path string, stats *cgroups.Stats) error {
 			stats.CpuStats.ThrottlingData.ThrottledTime = v
 		}
 	}
+
+	value, err := getCgroupParamUint(path, "cpu.cfs_quota_us")
+	if err != nil {
+		return err
+	}
+	stats.CpuStats.CpuLimits.CpuQuota = int64(value)
+	value, err = getCgroupParamUint(path, "cpu.cfs_period_us")
+	if err != nil {
+		return err
+	}
+	stats.CpuStats.CpuLimits.CpuPeriod = value
+	value, err = getCgroupParamUint(path, "cpu.shares")
+	if err != nil {
+		return err
+	}
+	stats.CpuStats.CpuLimits.CpuShares = value
+
 	return nil
 }

--- a/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/cgroups/stats.go
@@ -28,9 +28,19 @@ type CpuUsage struct {
 	UsageInUsermode uint64 `json:"usage_in_usermode"`
 }
 
+type CpuLimits struct {
+	// CPU shares (relative weight vs. other containers)
+	CpuShares uint64 `json:"cpu_shares"`
+	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	CpuQuota int64 `json:"cpu_quota"`
+	// CPU period to be used for hardcapping (in usecs). 0 to use system default.
+	CpuPeriod uint64 `json:"cpu_period"`
+}
+
 type CpuStats struct {
 	CpuUsage       CpuUsage       `json:"cpu_usage,omitempty"`
 	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
+	CpuLimits      CpuLimits      `json:"cpu_limits,omitempty"`
 }
 
 type MemoryData struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
If resource update of a Pod's containers results in net-increase of resources, we need to raise the Pod-level cgroup limits before calling CRI update. Conversely, if there is net-decrease, we lower Pod-level cgroup limits in the end. This is necessary to avoid random OOM kills or CPU limit update failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
